### PR TITLE
Fixed Moq version to 4.18.4 before migrate to other mock lib

### DIFF
--- a/src/Codehard.Functional/Codehard.Functional.AspNetCore.Tests/Codehard.Functional.AspNetCore.Tests.csproj
+++ b/src/Codehard.Functional/Codehard.Functional.AspNetCore.Tests/Codehard.Functional.AspNetCore.Tests.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-        <PackageReference Include="Moq" Version="4.18.4" />
+        <PackageReference Include="Moq" Version="[4.18.4]" />
         <PackageReference Include="xunit" Version="2.5.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Codehard.Functional/Codehard.Functional.Logger.Tests/Codehard.Functional.Logger.Tests.csproj
+++ b/src/Codehard.Functional/Codehard.Functional.Logger.Tests/Codehard.Functional.Logger.Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Moq" Version="[4.18.4]" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Regarding the issues for Moq version >= 4.20.x

- https://github.com/moq/moq/issues/1372
- https://github.com/moq/moq/issues/1370
- https://github.com/moq/moq/issues/1371

Moq is no longer trustable, so this PR is an attempt to prevent Moq's shenanigans before we move on to another mock library.