### PR TITLE
Add DddDbContext

### DIFF
--- a/src/Codehard.Common/Codehard.Common.DomainModel/Entity.cs
+++ b/src/Codehard.Common/Codehard.Common.DomainModel/Entity.cs
@@ -26,7 +26,7 @@ public abstract class Entity<TKey>
     /// <summary>
     /// Gets the unique identifier for the entity.
     /// </summary>
-    public abstract TKey Id { get; protected init; }
+    public abstract TKey Id { get; init; }
 
     /// <summary>
     /// Gets a read-only collection of notifications associated with the entity.

--- a/src/Codehard.Functional/Codehard.Functional.EntityFramework/Extensions/QueryableExtensions.cs
+++ b/src/Codehard.Functional/Codehard.Functional.EntityFramework/Extensions/QueryableExtensions.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Threading;
-using System.Threading.Tasks;
 using LanguageExt;
 
 using static LanguageExt.Prelude;
@@ -161,6 +156,28 @@ public static class QueryableExtensions
         return
             Aff(async () =>
                 await source.SingleOrNoneAsync(predicate, ct));
+    }
+    
+    /// <summary>
+    /// Asynchronously returns the only element of a sequence satisfying a specified condition within an Aff monad.
+    /// This method will returns fail if no such element exists or if more than one element satisfies the condition.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the elements in the sequence.</typeparam>
+    /// <param name="source">The IQueryable&lt;TSource&gt; to get the single element from.</param>
+    /// <param name="predicate">A lambda expression representing the condition to satisfy.</param>
+    /// <param name="ct">The CancellationToken to observe while waiting for the task to complete.</param>
+    /// <returns>
+    /// An Aff&lt;TSource&gt; that represents the asynchronous operation.
+    /// The Aff monad wraps the result, which is the only element of the sequence satisfying the specified condition.
+    /// </returns>
+    public static Aff<TSource> SingleOrFailAff<TSource>(
+        this IQueryable<TSource> source,
+        Expression<Func<TSource, bool>> predicate,
+        CancellationToken ct = default)
+    {
+        return
+            Aff(async () =>
+                await source.SingleAsync(predicate, ct));
     }
     
     /// <summary>

--- a/src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework.Tests/DddEntityTests.cs
+++ b/src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework.Tests/DddEntityTests.cs
@@ -1,0 +1,183 @@
+using Codehard.Infrastructure.EntityFramework.Tests.Entities.DomainDrivenDesign;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Codehard.Infrastructure.EntityFramework.Tests;
+
+public class DddEntityTests
+{
+    [Fact]
+    public async Task WhenSaveAggregateRoot_UsingDddDbContext_ThenSaveAllEntities()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<TestDddDbContext>()
+            .UseSqlite(CreateInMemoryDatabase())
+            .Options;
+        
+        await using var context = new TestDddDbContext(options);
+        
+        await context.Database.EnsureCreatedAsync();
+        
+        var a = new DddA { Id = Guid.NewGuid() };
+        var b1 = new DddB { Id = Guid.NewGuid() };
+        var c1 = new DddC { Id = Guid.NewGuid() };
+        
+        a.AddB(b1);
+        b1.AddC(c1);
+        context.As.Add(a);
+        
+        await context.SaveChangesAsync();
+        
+        context.ChangeTracker.Clear();
+        
+        // Act
+        var savedA = await context.As
+            .Include(dddA => dddA.Bs)
+            .ThenInclude(dddB => dddB.Cs)
+            .SingleAsync(dddA => dddA.Id == a.Id);
+        
+        // Assert
+        Assert.NotNull(savedA);
+        Assert.NotEmpty(savedA.Bs);
+        Assert.NotEmpty(savedA.Bs.First().Cs);
+    }
+    
+    [Fact]
+    public async Task WhenAddNonAggregateRootDirectly_UsingDddDbContextSet_ThenExceptionIsThrown()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<TestDddDbContext>()
+            .UseSqlite(CreateInMemoryDatabase())
+            .Options;
+        
+        await using var context = new TestDddDbContext(options);
+        
+        await context.Database.EnsureCreatedAsync();
+        
+        var b1 = new DddB { Id = Guid.NewGuid() };
+        var c1 = new DddC { Id = Guid.NewGuid() };
+        
+        b1.AddC(c1);
+
+        InvalidOperationException? exception = null;
+        
+        // Act
+        try
+        {
+            context.Set<DddB>().Add(b1);
+        }
+        catch (InvalidOperationException e)
+        {
+            exception = e;
+        }
+        
+        // Assert
+        Assert.NotNull(exception);
+    }
+    
+    [Fact]
+    public async Task WhenAddNonAggregateRootDirectly_UsingDddDbContext_ThenExceptionIsThrown()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<TestDddDbContext>()
+            .UseSqlite(CreateInMemoryDatabase())
+            .Options;
+        
+        await using var context = new TestDddDbContext(options);
+        
+        await context.Database.EnsureCreatedAsync();
+        
+        var b1 = new DddB { Id = Guid.NewGuid() };
+        var c1 = new DddC { Id = Guid.NewGuid() };
+        
+        b1.AddC(c1);
+
+        InvalidOperationException? exception = null;
+        
+        // Act
+        try
+        {
+            context.Add(b1);
+        }
+        catch (InvalidOperationException e)
+        {
+            exception = e;
+        }
+        
+        // Assert
+        Assert.NotNull(exception);
+    }
+    
+    [Fact]
+    public async Task WhenAddNonAggregateRootDirectly_UsingDddDbContextGenericAsync_ThenExceptionIsThrown()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<TestDddDbContext>()
+            .UseSqlite(CreateInMemoryDatabase())
+            .Options;
+        
+        await using var context = new TestDddDbContext(options);
+        
+        await context.Database.EnsureCreatedAsync();
+        
+        var b1 = new DddB { Id = Guid.NewGuid() };
+        var c1 = new DddC { Id = Guid.NewGuid() };
+        
+        b1.AddC(c1);
+
+        InvalidOperationException? exception = null;
+        
+        // Act
+        try
+        {
+            await context.AddAsync(b1);
+        }
+        catch (InvalidOperationException e)
+        {
+            exception = e;
+        }
+        
+        // Assert
+        Assert.NotNull(exception);
+    }
+    
+    [Fact]
+    public async Task WhenAddNonAggregateRootDirectly_UsingDddDbContextAsync_ThenExceptionIsThrown()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<TestDddDbContext>()
+            .UseSqlite(CreateInMemoryDatabase())
+            .Options;
+        
+        await using var context = new TestDddDbContext(options);
+        
+        await context.Database.EnsureCreatedAsync();
+        
+        var b1 = new DddB { Id = Guid.NewGuid() };
+        var c1 = new DddC { Id = Guid.NewGuid() };
+        
+        b1.AddC(c1);
+
+        InvalidOperationException? exception = null;
+        
+        // Act
+        try
+        {
+            await context.AddAsync((object)b1);
+        }
+        catch (InvalidOperationException e)
+        {
+            exception = e;
+        }
+        
+        // Assert
+        Assert.NotNull(exception);
+    }
+    
+    private static SqliteConnection CreateInMemoryDatabase()
+    {
+        var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        return connection;
+    }
+}

--- a/src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework.Tests/DomainEntityTests.cs
+++ b/src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework.Tests/DomainEntityTests.cs
@@ -21,10 +21,12 @@ public class DomainEntityTests
 
         var loggerMock = new Mock<ILogger<TestDbContext>>();
         var logger = loggerMock.Object;
+        
         await using var context = new TestDbContext(
             options,
             builder => builder.ApplyConfigurationsFromAssemblyFor<TestDbContext>(assembly),
             logger);
+        
         await context.Database.EnsureCreatedAsync();
 
         // Act

--- a/src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework.Tests/Entities/DomainDrivenDesign/DddA.cs
+++ b/src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework.Tests/Entities/DomainDrivenDesign/DddA.cs
@@ -1,0 +1,17 @@
+using Codehard.Common.DomainModel;
+
+namespace Codehard.Infrastructure.EntityFramework.Tests.Entities.DomainDrivenDesign;
+
+public class DddA : Entity<Guid>, IAggregateRoot<Guid>
+{
+    public override Guid Id { get; init; }
+    
+    private readonly List<DddB> bs = new();
+    
+    public IReadOnlyCollection<DddB> Bs => bs.AsReadOnly();
+    
+    public void AddB(DddB b)
+    {
+        bs.Add(b);
+    }
+}

--- a/src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework.Tests/Entities/DomainDrivenDesign/DddB.cs
+++ b/src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework.Tests/Entities/DomainDrivenDesign/DddB.cs
@@ -1,0 +1,19 @@
+using Codehard.Common.DomainModel;
+
+namespace Codehard.Infrastructure.EntityFramework.Tests.Entities.DomainDrivenDesign;
+
+public class DddB : Entity<Guid>
+{
+    public override Guid Id { get; init; }
+    
+    public DddA A { get; private set; } = null!;
+    
+    private readonly List<DddC> cs = new();
+    
+    public IReadOnlyCollection<DddC> Cs => cs.AsReadOnly();
+    
+    public void AddC(DddC c)
+    {
+        cs.Add(c);
+    }
+}

--- a/src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework.Tests/Entities/DomainDrivenDesign/DddC.cs
+++ b/src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework.Tests/Entities/DomainDrivenDesign/DddC.cs
@@ -1,0 +1,10 @@
+using Codehard.Common.DomainModel;
+
+namespace Codehard.Infrastructure.EntityFramework.Tests.Entities.DomainDrivenDesign;
+
+public class DddC : Entity<Guid>
+{
+    public override Guid Id { get; init; }
+    
+    public DddB B { get; private set; } = null!;
+}

--- a/src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework.Tests/Entities/EntityA.cs
+++ b/src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework.Tests/Entities/EntityA.cs
@@ -26,7 +26,7 @@ public struct EntityAKey
 
 public class EntityA : Entity<EntityAKey>
 {
-    public override EntityAKey Id { get; protected init; }
+    public override EntityAKey Id { get; init; }
 
     public string Value { get; set; } = string.Empty;
     

--- a/src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework.Tests/TestDddDbContext.cs
+++ b/src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework.Tests/TestDddDbContext.cs
@@ -1,0 +1,14 @@
+using Codehard.Infrastructure.EntityFramework.DbContexts;
+using Codehard.Infrastructure.EntityFramework.Tests.Entities.DomainDrivenDesign;
+using Microsoft.EntityFrameworkCore;
+
+namespace Codehard.Infrastructure.EntityFramework.Tests;
+
+public class TestDddDbContext : DddDbContext
+{
+    public TestDddDbContext(DbContextOptions options) : base(options)
+    {
+    }
+    
+    public DbSet<DddA> As { get; set; }
+}

--- a/src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework/DbContexts/DddDbContext.cs
+++ b/src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework/DbContexts/DddDbContext.cs
@@ -196,7 +196,6 @@ public class DddDbContext : DbContext
         base.AddRange(entities);
     }
     
-    
     /// <summary>
     /// Asynchronously adds the given aggregate root entities to the context.
     /// </summary>

--- a/src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework/DbContexts/DddDbContext.cs
+++ b/src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework/DbContexts/DddDbContext.cs
@@ -1,0 +1,304 @@
+using Codehard.Common.DomainModel;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+
+namespace Codehard.Infrastructure.EntityFramework.DbContexts;
+
+/// <summary>
+/// Base class for DbContexts that enforce the use of aggregate roots.
+/// </summary>
+public class DddDbContext : DbContext
+{
+    /// <summary>
+    /// Create a new instance of <see cref="DddDbContext"/>.
+    /// </summary>
+    /// <param name="options"></param>
+    protected DddDbContext(DbContextOptions options) : base(options) { }
+
+    /// <summary>
+    /// Create a DbSet for an aggregate root entity.
+    /// </summary>
+    /// <typeparam name="TEntity"></typeparam>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    public new DbSet<TEntity> Set<TEntity>() where TEntity : class
+    {
+        if (!typeof(IAggregateRoot<>).IsAssignableFrom(typeof(TEntity)))
+        {
+            throw new InvalidOperationException($"Cannot create DbSet for {typeof(TEntity).Name} as it is not an aggregate root.");
+        }
+        return base.Set<TEntity>();
+    }
+    
+    /// <summary>
+    /// Adds the specified aggregate root entity to the context.
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <typeparam name="TEntity"></typeparam>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    public override EntityEntry<TEntity> Add<TEntity>(TEntity entity)
+    {
+        if (!typeof(IAggregateRoot<>).IsAssignableFrom(typeof(TEntity)))
+        {
+            throw new InvalidOperationException($"Cannot add {typeof(TEntity).Name} directly as it is not an aggregate root.");
+        }
+        return base.Add(entity);
+    }
+    
+    /// <summary>
+    /// Adds the given aggregate root entity to the context.
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    public override EntityEntry Add(object entity)
+    {
+        if (!typeof(IAggregateRoot<>).IsAssignableFrom(entity.GetType()))
+        {
+            throw new InvalidOperationException($"Cannot add {entity.GetType().Name} directly as it is not an aggregate root.");
+        }
+        return base.Add(entity);
+    }
+    
+    /// <summary>
+    /// Asynchronously adds the specified aggregate root entity to the context.
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    public override ValueTask<EntityEntry> AddAsync(
+        object entity,
+        CancellationToken cancellationToken = default)
+    {
+        if (!typeof(IAggregateRoot<>).IsAssignableFrom(entity.GetType()))
+        {
+            throw new InvalidOperationException($"Cannot add {entity.GetType().Name} directly as it is not an aggregate root.");
+        }
+        
+        return base.AddAsync(entity, cancellationToken);
+    }
+    
+    /// <summary>
+    /// Asynchronously adds the specified aggregate root entity to the context.
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <param name="cancellationToken"></param>
+    /// <typeparam name="TEntity"></typeparam>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    public override ValueTask<EntityEntry<TEntity>> AddAsync<TEntity>(
+        TEntity entity,
+        CancellationToken cancellationToken = default)
+    {
+        if (!typeof(IAggregateRoot<>).IsAssignableFrom(typeof(TEntity)))
+        {
+            throw new InvalidOperationException($"Cannot add {typeof(TEntity).Name} directly as it is not an aggregate root.");
+        }
+        return base.AddAsync(entity, cancellationToken);
+    }
+    
+    /// <summary>
+    /// Updates the given aggregate root entity in the context.
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <typeparam name="TEntity"></typeparam>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    public override EntityEntry<TEntity> Update<TEntity>(TEntity entity)
+    {
+        if (!typeof(IAggregateRoot<>).IsAssignableFrom(typeof(TEntity)))
+        {
+            throw new InvalidOperationException($"Cannot update {typeof(TEntity).Name} directly as it is not an aggregate root.");
+        }
+        return base.Update(entity);
+    }
+    
+    /// <summary>
+    /// Updates the given aggregate root entity in the context.
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    public override EntityEntry Update(object entity)
+    {
+        if (!typeof(IAggregateRoot<>).IsAssignableFrom(entity.GetType()))
+        {
+            throw new InvalidOperationException($"Cannot update {entity.GetType().Name} directly as it is not an aggregate root.");
+        }
+        return base.Update(entity);
+    }
+
+    /// <summary>
+    /// Removes the given aggregate root entity from the context.
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <typeparam name="TEntity"></typeparam>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    public override EntityEntry<TEntity> Remove<TEntity>(TEntity entity)
+    {
+        if (!typeof(IAggregateRoot<>).IsAssignableFrom(typeof(TEntity)))
+        {
+            throw new InvalidOperationException($"Cannot remove {typeof(TEntity).Name} directly as it is not an aggregate root.");
+        }
+        
+        return base.Remove(entity);
+    }
+
+    /// <summary>
+    /// Removes the given aggregate root entity from the context.
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    public override EntityEntry Remove(object entity)
+    {
+        if (!typeof(IAggregateRoot<>).IsAssignableFrom(entity.GetType()))
+        {
+            throw new InvalidOperationException($"Cannot remove {entity.GetType().Name} directly as it is not an aggregate root.");
+        }
+        return base.Remove(entity);
+    }
+    
+    /// <summary>
+    /// Adds the given aggregate root entities to the context.
+    /// </summary>
+    /// <param name="entities"></param>
+    /// <exception cref="InvalidOperationException"></exception>
+    public override void AddRange(params object[] entities)
+    {
+        foreach (var entity in entities)
+        {
+            if (!typeof(IAggregateRoot<>).IsAssignableFrom(entity.GetType()))
+            {
+                throw new InvalidOperationException($"Cannot add {entity.GetType().Name} directly as it is not an aggregate root.");
+            }
+        }
+        base.AddRange(entities);
+    }
+
+    /// <summary>
+    /// Adds the given aggregate root entities to the context.
+    /// </summary>
+    /// <param name="entities"></param>
+    /// <exception cref="InvalidOperationException"></exception>
+    public override void AddRange(IEnumerable<object> entities)
+    {
+        foreach (var entity in entities)
+        {
+            if (!typeof(IAggregateRoot<>).IsAssignableFrom(entity.GetType()))
+            {
+                throw new InvalidOperationException($"Cannot add {entity.GetType().Name} directly as it is not an aggregate root.");
+            }
+        }
+        base.AddRange(entities);
+    }
+    
+    
+    /// <summary>
+    /// Asynchronously adds the given aggregate root entities to the context.
+    /// </summary>
+    /// <param name="entities"></param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    public override Task AddRangeAsync(params object[] entities)
+    {
+        foreach (var entity in entities)
+        {
+            if (!typeof(IAggregateRoot<>).IsAssignableFrom(entity.GetType()))
+            {
+                throw new InvalidOperationException($"Cannot add {entity.GetType().Name} directly as it is not an aggregate root.");
+            }
+        }
+        return base.AddRangeAsync(entities);
+    }
+    
+    /// <summary>
+    /// Asynchronously adds the given aggregate root entities to the context.
+    /// </summary>
+    /// <param name="entities"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    public override Task AddRangeAsync(IEnumerable<object> entities, CancellationToken cancellationToken = default)
+    {
+        foreach (var entity in entities)
+        {
+            if (!typeof(IAggregateRoot<>).IsAssignableFrom(entity.GetType()))
+            {
+                throw new InvalidOperationException($"Cannot add {entity.GetType().Name} directly as it is not an aggregate root.");
+            }
+        }
+        return base.AddRangeAsync(entities, cancellationToken);
+    }
+
+    /// <summary>
+    /// Update the given aggregate root entities to the context.
+    /// </summary>
+    /// <param name="entities"></param>
+    /// <exception cref="InvalidOperationException"></exception>
+    public override void UpdateRange(params object[] entities)
+    {
+        foreach (var entity in entities)
+        {
+            if (!typeof(IAggregateRoot<>).IsAssignableFrom(entity.GetType()))
+            {
+                throw new InvalidOperationException($"Cannot update {entity.GetType().Name} directly as it is not an aggregate root.");
+            }
+        }
+        base.UpdateRange(entities);
+    }
+
+    /// <summary>
+    /// Update the given aggregate root entities to the context.
+    /// </summary>
+    /// <param name="entities"></param>
+    /// <exception cref="InvalidOperationException"></exception>
+    public override void UpdateRange(IEnumerable<object> entities)
+    {
+        foreach (var entity in entities)
+        {
+            if (!typeof(IAggregateRoot<>).IsAssignableFrom(entity.GetType()))
+            {
+                throw new InvalidOperationException($"Cannot update {entity.GetType().Name} directly as it is not an aggregate root.");
+            }
+        }
+        base.UpdateRange(entities);
+    }
+
+    /// <summary>
+    /// Remove the given aggregate root entities to the context.
+    /// </summary>
+    /// <param name="entities"></param>
+    /// <exception cref="InvalidOperationException"></exception>
+    public override void RemoveRange(params object[] entities)
+    {
+        foreach (var entity in entities)
+        {
+            if (!typeof(IAggregateRoot<>).IsAssignableFrom(entity.GetType()))
+            {
+                throw new InvalidOperationException($"Cannot remove {entity.GetType().Name} directly as it is not an aggregate root.");
+            }
+        }
+        base.RemoveRange(entities);
+    }
+
+    /// <summary>
+    /// Remove the given aggregate root entities to the context.
+    /// </summary>
+    /// <param name="entities"></param>
+    /// <exception cref="InvalidOperationException"></exception>
+    public override void RemoveRange(IEnumerable<object> entities)
+    {
+        foreach (var entity in entities)
+        {
+            if (!typeof(IAggregateRoot<>).IsAssignableFrom(entity.GetType()))
+            {
+                throw new InvalidOperationException($"Cannot remove {entity.GetType().Name} directly as it is not an aggregate root.");
+            }
+        }
+        base.RemoveRange(entities);
+    }
+}

--- a/src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework/Extensions/ModelBuilderExtensions.cs
+++ b/src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework/Extensions/ModelBuilderExtensions.cs
@@ -3,6 +3,10 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Codehard.Infrastructure.EntityFramework.Extensions;
 
+/// <summary>
+/// Provides extension methods for the ModelBuilder class.
+/// These methods allow for applying entity type configurations from a specified assembly to the model.
+/// </summary>
 public static class ModelBuilderExtensions
 {
     /// <summary>

--- a/src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework/Extensions/SpecificationExtensions.cs
+++ b/src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework/Extensions/SpecificationExtensions.cs
@@ -1,7 +1,11 @@
 using Microsoft.EntityFrameworkCore;
 
+// ReSharper disable once CheckNamespace
 namespace Codehard.Common.DomainModel.Extensions;
 
+/// <summary>
+/// Provides extension methods for applying specifications to a DbSet.
+/// </summary>
 public static class SpecificationExtensions
 {
     /// <summary>


### PR DESCRIPTION

---------- Review by CodeLleviewer ----------
 Summary:
The pull request introduces a new DddDbContext and related entities that follow Domain-Driven Design (DDD) best practices, such as using an Aggregate Root pattern and implementing a protected setter for the entity's Id property. The necessary changes are made to the existing QueryableExtensions class to support this new context.

Additions:

* New DddDbContext added in `src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework/DbContexts/DddDbContext.cs` for Domain-Driven Design related entities, including DddA, DddB and DddC classes, with the proper AggregateRoot pattern implementation and protected setter for the entity's Id property.
* Extension methods added to `src/Codehard.Functional/Codehard.Functional.EntityFramework/Extensions/QueryableExtensions.cs` class to support IQueryable operations on DddDbContext.
* Test cases added in `src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework.Tests/DddEntityTests.cs`, `src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework.Tests/DomainEntityTests.cs` for DddDbContext, and related entities to ensure proper functionality.

Updates:

* The base Entity class in `src/Codehard.Common/Codehard.Common.DomainModel/Entity.cs` is updated with a protected setter for the Id property instead of public init accessor.

Deletes:

* Test classes `DddA`, `DddB`, and `DddC` in `src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework.Tests/Entities/DomainDrivenDesign/` have been removed since they are replaced by their DDD-compliant versions with an AggregateRoot pattern implementation.

Review order:
1. Begin with the high-level changes in `src/Codehard.Common/Codehard.Common.DomainModel/Entity.cs`. Review how Entity class has been updated to include a protected setter for the Id property.
2. Move on to `src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework/DbContexts/DddDbContext.cs` and check the new DddDbContext implementation, including relationships between DddA, DddB, and DddC entities.
3. Continue with the extension methods in `src/Codehard.Functional/Codehard.Functional.EntityFramework/Extensions/QueryableExtensions.cs`, which support IQueryable operations on the new DddDbContext.
4. Explore test cases for the new context and entities, starting from `src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework.Tests/DddEntityTests.cs` and then checking `src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework.Tests/DomainEntityTests.cs`.

Suggestions:
- Consider adding a DbContextFactory for easily creating instances of DddDbContext in the tests.
- Think about implementing an OnModelCreating method to separate entity configuration from extension methods in `src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework/Extensions/ModelBuilderExtensions.cs`.
- Explore moving common functionality between different contexts into a shared base class or a set of extension methods for better code reusability.

---------- Review by CodeLleviewer ----------

 
Summary
-------
The pull request introduces a new DddDbContext and related entities that follow Domain-Driven Design (DDD) best practices, such as using an Aggregate Root pattern and implementing a protected setter for the entity's Id property. The necessary changes are made to the existing QueryableExtensions class to support this new context.
Additions
---------
* A new DddDbContext has been added in `src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework/DbContexts/DddDbContext.cs` for Domain-Driven Design related entities, including DddA, DddB and DddC classes.
* Extension methods have been added to `src/Codehard.Functional/Codehard.Functional.EntityFramework/Extensions/QueryableExtensions.cs` class to support IQueryable operations on DddDbContext.
* Test cases for the new context and entities have been added in `src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework.Tests/DddEntityTests.cs` and `src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework.Tests/DomainEntityTests.cs`.
Updates
-------
* The base Entity class in `src/Codehard.Common/Codehard.Common.DomainModel/Entity.cs` is updated with a protected setter for the Id property instead of public init accessor.
Deletes
-------
* Test classes DddA, DddB, and DddC have been removed from `src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework.Tests/Entities/DomainDrivenDesign/` since they are replaced by their DDD-compliant versions with an AggregateRoot pattern implementation.
Review order
------------
1. Begin with the high-level changes in `src/Codehard.Common/Codehard.Common.DomainModel/Entity.cs`. Review how Entity class has been updated to include a protected setter for the Id property.
2. Move on to `src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework/DbContexts/DddDbContext.cs` and review the new DDD-compliant entities.
3. Explore test cases for the new context and entities, starting from `src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework.Tests/DddEntityTests.cs` and then checking `src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework.Tests/DomainEntityTests.cs`.
Security review
--------------
No sensitive data has been added or exposed in the new codebase.
Suggestions
-----------
* Consider adding a DbContextFactory for easily creating instances of DddDbContext in the tests.
* Think about implementing an OnModelCreating method to separate entity configuration from extension methods in `src/Codehard.Infrastructure/Codehard.Infrastructure.EntityFramework/Extensions/ModelBuilderExtensions.cs`.
* Explore moving common functionality between different contexts into a shared base class or a set of extension methods for better code reusability.